### PR TITLE
Fix MCK rate setting read

### DIFF
--- a/NetworkInterface.c
+++ b/NetworkInterface.c
@@ -320,7 +320,7 @@ uint8_t result;
 
 	/* Get master clock (MCK) speed; must not exceed 240Mhz for GMAC Management Data Clock (MDC) to 
 	 * conform to 802.3 spec. (CPU Clock may need to be downscaled to work [see CONFIG_SYSCLK_PRES]) */
-	mck_hz = sysclk_get_cpu_hz();
+	mck_hz = sysclk_get_peripheral_hz();
 	
 	/* Initialize the Ethernet PHY and store its address for later use */
 	/* JB: NOTE, ethernet_phy_init from ASF was rewritten to return the PHY address */


### PR DESCRIPTION
`sysclk_get_cpu_hz()` returns HCLK, not MCK. MCK comes out of a clock divider, with HCLK as its input. This divider which sets the MCK frequency is configured in `conf_clock.h` with `#define CONFIG_SYSCLK_DIV`.

Looking at the source code in `ASF/common/services/clock/<CPU name>/sysclk.h` we note that `CONFIG_SYSCLK_DIV` is used in `sysclk_get_peripheral_hz()` and not `sysclk_get_cpu_hz()`.

![capture](https://user-images.githubusercontent.com/6827790/32857339-5932f416-c9fc-11e7-91a5-59964c8e04ac.PNG)
